### PR TITLE
fix(typescript): allow explicit-any

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1179,7 +1179,7 @@ module.exports = {
 				'@typescript-eslint/no-dynamic-delete':                      'error',
 				'@typescript-eslint/no-empty-function':                      noEmptyFunction,
 				'@typescript-eslint/no-empty-interface':                     'error',
-				'@typescript-eslint/no-explicit-any':                        'error',
+				'@typescript-eslint/no-explicit-any':                        'warn',
 				'@typescript-eslint/no-extra-non-null-assertion':            'error',
 				'@typescript-eslint/no-extra-parens':                        noExtraParens,
 				'@typescript-eslint/no-extra-semi':                          'error',


### PR DESCRIPTION
function overrides require you to use any. Without an alternative solution, this has to happen.